### PR TITLE
build(deps): Bump PHP, deps and CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '15 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: 'PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}'
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Markdown
 
-[![CI](https://github.com/JBZoo/Markdown/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Markdown/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Markdown/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Markdown?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Markdown/coverage.svg)](https://shepherd.dev/github/JBZoo/Markdown)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Markdown/level.svg)](https://shepherd.dev/github/JBZoo/Markdown)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/markdown/badge)](https://www.codefactor.io/repository/github/jbzoo/markdown/issues)    
+[![CI](https://github.com/JBZoo/Markdown/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Markdown/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Markdown/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Markdown?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Markdown/coverage.svg)](https://shepherd.dev/github/JBZoo/Markdown)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Markdown/level.svg)](https://shepherd.dev/github/JBZoo/Markdown)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/markdown/badge)](https://www.codefactor.io/repository/github/jbzoo/markdown/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/markdown/version)](https://packagist.org/packages/jbzoo/markdown/)    [![Total Downloads](https://poser.pugx.org/jbzoo/markdown/downloads)](https://packagist.org/packages/jbzoo/markdown/stats)    [![Dependents](https://poser.pugx.org/jbzoo/markdown/dependents)](https://packagist.org/packages/jbzoo/markdown/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/markdown)](https://github.com/JBZoo/Markdown/blob/master/LICENSE)
 
 
@@ -52,7 +52,7 @@ Result
   |   999 |    123    |       456 |
   |  1000 |   789_1   |      9871 |
   |  1001 |   789_2   |           |
-  
+
 </details>
 
 
@@ -84,16 +84,16 @@ Markdown::blockquote(['Quote LIne 1', 'Quote LIne 2', 'Quote LIne 3'])
 
 // <details>
 //   <summary>Quote Text</summary>
-//   
+//
 //   Some hidden text
-//   
+//
 // </details>
 Markdown::spoiler('Quote Text', 'Some hidden text');
 
 // ```php
 // <?php
 // echo 1;
-// 
+//
 // ```
 Markdown::code("<?php\necho 1;\n", 'php');
 

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.1",
-        "jbzoo/utils" : "^7.1"
+        "php"         : "^8.2",
+        "jbzoo/utils" : "^7.3"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.2"
     },
 
     "autoload"          : {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\Markdown;
 
-class Exception extends \RuntimeException
+final class Exception extends \RuntimeException
 {
 }

--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -20,7 +20,10 @@ use JBZoo\Utils\Str;
 
 use function JBZoo\Utils\isStrEmpty;
 
-class Markdown
+/**
+ * @psalm-suppress UnusedClass
+ */
+final class Markdown
 {
     /**
      * Insert link to Markdown text.

--- a/src/Table.php
+++ b/src/Table.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\Markdown;
 
-class Table
+final class Table
 {
     public const ALIGN_LEFT   = 'Left';
     public const ALIGN_CENTER = 'Center';
@@ -123,7 +123,7 @@ class Table
     /**
      * @param array[] $actualRows
      */
-    protected function calculateWidths(array $actualHeaders, array $actualRows): array
+    private function calculateWidths(array $actualHeaders, array $actualRows): array
     {
         $widths = [];
 
@@ -147,7 +147,7 @@ class Table
      * @param  int[]      $widths
      * @throws \Exception
      */
-    protected function renderHeaders(array $widths, array $actualHeaders): string
+    private function renderHeaders(array $widths, array $actualHeaders): string
     {
         $result = '| ';
 
@@ -168,7 +168,7 @@ class Table
      * @param  int[]      $widths
      * @throws \Exception
      */
-    protected function renderRows(array $widths, array $actualRows): string
+    private function renderRows(array $widths, array $actualRows): string
     {
         $result = '';
 
@@ -195,7 +195,7 @@ class Table
     /**
      * @param int[] $widths
      */
-    protected function renderAlignments(array $widths): string
+    private function renderAlignments(array $widths): string
     {
         $row = '|';
 
@@ -221,7 +221,7 @@ class Table
         return $row;
     }
 
-    protected function getColumnAlign(int|string $colIndex): string
+    private function getColumnAlign(int|string $colIndex): string
     {
         $validAligns      = [self::ALIGN_LEFT, self::ALIGN_CENTER, self::ALIGN_RIGHT];
         $actualAlignments = $this->alignments;
@@ -239,7 +239,12 @@ class Table
         return $result;
     }
 
-    protected static function renderCell(string $contents, string $alignment, int $width): string
+    private function isAutoIndexEnabled(): bool
+    {
+        return \count($this->autoIndexConfig) > 0;
+    }
+
+    private static function renderCell(string $contents, string $alignment, int $width): string
     {
         $map = [
             self::ALIGN_LEFT   => \STR_PAD_RIGHT,
@@ -250,10 +255,5 @@ class Table
         $padType = $map[$alignment] ?? \STR_PAD_LEFT;
 
         return \str_pad($contents, $width, ' ', $padType);
-    }
-
-    private function isAutoIndexEnabled(): bool
-    {
-        return \count($this->autoIndexConfig) > 0;
     }
 }


### PR DESCRIPTION
- Require PHP ^8.2 and bump jbzoo/utils to ^7.3 and jbzoo/toolbox-dev to ^7.2
- Update GitHub Actions: add permissions.contents read, remove scheduled cron, expand PHP matrix to 8.2–8.4, upgrade actions/upload-artifact to v4
- Tighten library code: mark classes final, change several protected methods to private, add Psalm suppress annotation, and fix README whitespace