### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,12 +37,12 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -65,11 +68,12 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: 'PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}'
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/.phan.php
+++ b/.phan.php
@@ -14,7 +14,7 @@
 
 declare(strict_types=1);
 
-$default = include __DIR__ . '/vendor/jbzoo/codestyle/src/phan/default.php';
+$default = include __DIR__ . '/vendor/jbzoo/codestyle/src/phan.php';
 
 return \array_merge($default, [
     'directory_list' => [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The codebase is minimal and well-structured:
 - `tests/` - PHPUnit tests covering all functionality
 
 Key dependencies:
-- PHP 8.2+ (strict typing throughout)
+- PHP 8.3+ (strict typing throughout)
 - `jbzoo/utils` for string utilities
 - `jbzoo/toolbox-dev` for development tools (PHPUnit, linters, etc.)
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Tools to render markdown text from PHP code. This library provides a simple and 
 
 - **Markdown Elements**: Generate links, titles, images, badges, blockquotes, spoilers, and code blocks
 - **Advanced Tables**: Create markdown tables with auto-indexing, custom alignments, and flexible rendering
-- **Type Safety**: Full PHP 8.2+ compatibility with strict typing
+- **Type Safety**: Full PHP 8.3+ compatibility with strict typing
 - **Fluent API**: Chainable methods for intuitive table building
 - **Zero Dependencies**: Lightweight with minimal external requirements
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - Composer
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # JBZoo / Markdown
 
-[![CI](https://github.com/JBZoo/Markdown/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Markdown/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Markdown/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Markdown?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Markdown/coverage.svg)](https://shepherd.dev/github/JBZoo/Markdown)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Markdown/level.svg)](https://shepherd.dev/github/JBZoo/Markdown)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/markdown/badge)](https://www.codefactor.io/repository/github/jbzoo/markdown/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/markdown/version)](https://packagist.org/packages/jbzoo/markdown/)    [![Total Downloads](https://poser.pugx.org/jbzoo/markdown/downloads)](https://packagist.org/packages/jbzoo/markdown/stats)    [![Dependents](https://poser.pugx.org/jbzoo/markdown/dependents)](https://packagist.org/packages/jbzoo/markdown/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/markdown)](https://github.com/JBZoo/Markdown/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Markdown/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Markdown/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Markdown/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Markdown?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Markdown/coverage.svg)](https://shepherd.dev/github/JBZoo/Markdown)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Markdown/level.svg)](https://shepherd.dev/github/JBZoo/Markdown)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/markdown/badge)](https://www.codefactor.io/repository/github/jbzoo/markdown/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/markdown/version)](https://packagist.org/packages/jbzoo/markdown/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/markdown/downloads)](https://packagist.org/packages/jbzoo/markdown/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/markdown/dependents)](https://packagist.org/packages/jbzoo/markdown/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/markdown)](https://github.com/JBZoo/Markdown/blob/master/LICENSE)
 
 Tools to render markdown text from PHP code. This library provides a simple and fluent API for generating markdown elements programmatically, including tables with advanced formatting options.
 

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.2",
-        "jbzoo/utils" : "^7.3"
+        "php"         : "^8.3",
+        "jbzoo/utils" : "^8.0"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.2"
+        "jbzoo/toolbox-dev" : "^8.0"
     },
 
     "autoload"          : {
@@ -46,7 +46,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,18 +11,21 @@
     @see        https://github.com/JBZoo/Markdown
 -->
 <phpunit bootstrap="tests/autoload.php"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
          executionOrder="random"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         stopOnRisky="false"
->
+         stopOnRisky="false">
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage_html" lowUpperBound="75" highLowerBound="95"/>
+            <clover outputFile="build/coverage_xml/main.xml"/>
+            <php outputFile="build/coverage_cov/main.cov"/>
+            <text outputFile="php://stdout" showUncoveredFiles="true" showOnlySummary="false"/>
+        </report>
+    </coverage>
 
     <testsuites>
         <testsuite name="All">
@@ -30,18 +33,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
     <logging>
-        <log type="coverage-html" target="build/coverage_html" lowUpperBound="75" highLowerBound="95"/>
-        <log type="coverage-clover" target="build/coverage_xml/main.xml"/>
-        <log type="coverage-php" target="build/coverage_cov/main.cov"/>
-        <log type="junit" target="build/coverage_junit/main.xml"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" showOnlySummary="false"/>
+        <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
 
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven; no public API change).

- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0`.
